### PR TITLE
Small Makefile improvements

### DIFF
--- a/webserver/Makefile
+++ b/webserver/Makefile
@@ -1,17 +1,19 @@
-CC=gcc
 CFLAGS=-Wall -Wextra -O2
 CHEADERS=$(shell ls *.h)
 CFILES=$(shell ls *.c)
 OBFILES=$(shell ls *.o)
 #HTMLFILES=$(shell ls *.html)
-LIBS=-pthread -lwurfl
+LDFLAGS=-pthread -lwurfl
 TARGET=server
 
 all: $(TARGET)
 
 $(TARGET): $(CFILES) $(CHEADERS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-cln:
-	-rm -v $(TARGET) $(OBFILES) # $(HTMLFILES)
+
+.PHONY: clean all
+
+clean:
+	-$(RM) -v $(TARGET) $(OBFILES) *~ # $(HTMLFILES)
 #	-rm -v -rf thumbs


### PR DESCRIPTION
Super-small improvements on Makefile:

* target `cln` renamed to `clean`.
* using `.PHONY` targets
* using Makefile macros
* using `LDFLAGS` as more appropriate name for linker flags
* you don't need to set CC to gcc unless you want to force it on platforms where this is not the default