### PR TITLE
Handle parsing errors explicitly; added debug build

### DIFF
--- a/webserver/Makefile
+++ b/webserver/Makefile
@@ -12,6 +12,9 @@ $(TARGET): $(CFILES) $(CHEADERS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
 
+debug: $(CFILES) $(CHEADERS)
+	$(CC) $(CFLAGS) -ggdb -o $@ $^ $(LDFLAGS)
+
 .PHONY: clean all
 
 clean:

--- a/webserver/parse_conf_file.h
+++ b/webserver/parse_conf_file.h
@@ -35,13 +35,13 @@ char * trim (char * s)
 }
 
 
-void parse_config()
+int parse_config()
 {
   char *s, buff[256];
   FILE *fp = fopen (CONFIG_FILE, "r");
   if (fp == NULL)
   {
-    return;
+    return 0;
   }
 
   /* Read next line */
@@ -79,4 +79,5 @@ void parse_config()
 
   /* Close file */
   fclose (fp);
+  return 1;
 }

--- a/webserver/server.c
+++ b/webserver/server.c
@@ -96,8 +96,11 @@ int main(int argc, char **argv)
 	fprintf(stdout, "Initializing parameters to default values...\n");
 	init_parameters();
 
-	fprintf(stdout, "Reading config file...\n");
-	parse_config();
+	fprintf(stdout, "Reading config file " CONFIG_FILE "\n");
+	if (!parse_config()) {
+		fprintf(stderr, "Failed to read config file: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
+	}
 
 	fprintf(stdout, "Final values:\n");
 	fprintf(stdout, "Server port: %s, Number of threads: %s, backlog: %s\n", config_file.port, config_file.threads, config_file.backlog);

--- a/webserver/server.cfg
+++ b/webserver/server.cfg
@@ -1,5 +1,0 @@
-#this is a comment
-
-server=9991
-threads=2
-backlog=10

--- a/webserver/utils.h
+++ b/webserver/utils.h
@@ -64,6 +64,6 @@ void usage(char *);
 /*configuration file functions*/
 void init_parameters();
 char *trim(char *);
-void parse_config();
+int parse_config();
 
 #endif				/*UTILS_H */


### PR DESCRIPTION
Two changes:
* `parse_config` now returns either 0 or 1, indicating respectively failure or success in reading the config file
* added debug build, to simplify debugging with `gdb`

For the first change, now the server prints an explicit message if `server.cfg` is missing:

```
$ ./server 
Initializing parameters to default values...
Reading config file server.cfg
Failed to read config file: No such file or directory
```